### PR TITLE
Minimal support for PVR Addon API 1.9.7

### DIFF
--- a/pvr.mythtv/addon.xml
+++ b/pvr.mythtv/addon.xml
@@ -6,7 +6,7 @@
   provider-name="Christian Fetzer, Jean-Luc Barrière">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="1.9.6"/>
+    <import addon="xbmc.pvr" version="1.9.7"/>
     <import addon="xbmc.gui" version="5.8.0"/>
     <import addon="xbmc.codec" version="1.0.1"/>
   </requires>

--- a/pvr.mythtv/addon.xml
+++ b/pvr.mythtv/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mythtv"
-  version="2.3.1"
+  version="3.0.0"
   name="MythTV PVR Client"
   provider-name="Christian Fetzer, Jean-Luc Barrière">
   <requires>

--- a/pvr.mythtv/changelog.txt
+++ b/pvr.mythtv/changelog.txt
@@ -1,3 +1,6 @@
+v3.0.0
+- Updated to API 1.9.7
+
 v2.3.1
 - Updated language files from Transifex
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -919,6 +919,12 @@ PVR_ERROR DeleteAllRecordingsFromTrash()
  * PVR Timer Functions
  */
 
+PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size)
+{
+  /* TODO: Implement this to get support for the timer features introduced with PVR API 1.9.7 */
+  return PVR_ERROR_NOT_IMPLEMENTED;
+}
+
 int GetTimersAmount(void)
 {
   if (g_client == NULL)
@@ -932,6 +938,7 @@ PVR_ERROR GetTimers(ADDON_HANDLE handle)
   if (g_client == NULL)
     return PVR_ERROR_SERVER_ERROR;
 
+  /* TODO: Change implementation to get support for the timer features introduced with PVR API 1.9.7 */
   return g_client->GetTimers(handle);
 }
 
@@ -943,11 +950,12 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer)
   return g_client->AddTimer(timer);
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool /*bDeleteScheduled*/)
 {
   if (g_client == NULL)
     return PVR_ERROR_SERVER_ERROR;
 
+  /* TODO: Change implementation to support bDeleteScheduled (introduced with PVR API 1.9.7 */
   return g_client->DeleteTimer(timer,bForceDelete);
 }
 


### PR DESCRIPTION
For, J***\* PVR Addon API will be bumped to version 1.9.7 to introduce a couple of new features and enhancements for timers (esp. official series recording support). => https://github.com/xbmc/xbmc/pull/7079

This PR will ensure compatibility with and add minimalistic support for PVR addon API 1.9.7. Even if the maintainers of this addon will do nothing except merging this PR and bump the addon version in Kodi, the addon will still be usable in J***\* and not loose any functionality compared to Isengard, but it will not profit from the new features. For the latter, every addon maintainer must do the respective changes on his own.
