### PR TITLE
Update to PVR addon API v4.0.0

### DIFF
--- a/pvr.mythtv/addon.xml.in
+++ b/pvr.mythtv/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mythtv"
-  version="3.3.2"
+  version="3.3.3"
   name="MythTV PVR Client"
   provider-name="Christian Fetzer, Jean-Luc Barrière">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="3.0.0"/>
+    <import addon="xbmc.pvr" version="4.0.0"/>
     <import addon="xbmc.gui" version="5.8.0"/>
     <import addon="xbmc.codec" version="1.0.1"/>
   </requires>

--- a/pvr.mythtv/changelog.txt
+++ b/pvr.mythtv/changelog.txt
@@ -1,3 +1,6 @@
+v3.3.3
+- Updated to PVR API v4.0.0
+
 v3.3.2
 - Workaround for Kodi bug 16141
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -995,13 +995,12 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer)
   return g_client->AddTimer(timer);
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteScheduled)
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
 {
   if (g_client == NULL)
     return PVR_ERROR_SERVER_ERROR;
 
-  /* TODO: Change implementation to support bDeleteScheduled (introduced with PVR API 1.9.7 */
-  return g_client->DeleteTimer(timer,bDeleteScheduled);
+  return g_client->DeleteTimer(timer, bForceDelete);
 }
 
 PVR_ERROR UpdateTimer(const PVR_TIMER &timer)

--- a/src/pvrclient-mythtv.cpp
+++ b/src/pvrclient-mythtv.cpp
@@ -1679,7 +1679,7 @@ PVR_ERROR PVRClientMythTV::AddTimer(const PVR_TIMER &timer)
   return PVR_ERROR_NO_ERROR;
 }
 
-PVR_ERROR PVRClientMythTV::DeleteTimer(const PVR_TIMER &timer, bool bDeleteScheduled)
+PVR_ERROR PVRClientMythTV::DeleteTimer(const PVR_TIMER &timer, bool force)
 {
   if (!m_scheduleManager)
     return PVR_ERROR_SERVER_ERROR;
@@ -1714,9 +1714,9 @@ PVR_ERROR PVRClientMythTV::DeleteTimer(const PVR_TIMER &timer, bool bDeleteSched
   }
 
   // Otherwise delete timer
-  XBMC->Log(LOG_DEBUG, "%s: Deleting timer %u force %s", __FUNCTION__, timer.iClientIndex, (bDeleteScheduled ? "true" : "false"));
+  XBMC->Log(LOG_DEBUG, "%s: Deleting timer %u force %s", __FUNCTION__, timer.iClientIndex, (force ? "true" : "false"));
   MythTimerEntry entry = PVRtoTimerEntry(timer, false);
-  MythScheduleManager::MSM_ERROR ret = m_scheduleManager->DeleteTimer(entry, bDeleteScheduled);
+  MythScheduleManager::MSM_ERROR ret = m_scheduleManager->DeleteTimer(entry, force);
   if (ret == MythScheduleManager::MSM_ERROR_FAILED)
     return PVR_ERROR_FAILED;
   if (ret == MythScheduleManager::MSM_ERROR_NOT_IMPLEMENTED)
@@ -1738,7 +1738,7 @@ MythTimerEntry PVRClientMythTV::PVRtoTimerEntry(const PVR_TIMER& timer, bool che
   time_t fd = timer.firstDay;
   time_t now = time(NULL);
 
-  if (checkEPG && (timer.iEpgUid > 0 || timer.iEpgUid < -1))
+  if (checkEPG && (timer.iEpgUid > PVR_TIMER_NO_EPG_UID))
   {
     entry.epgCheck = true;
     hasEpg = true;

--- a/src/pvrclient-mythtv.h
+++ b/src/pvrclient-mythtv.h
@@ -108,7 +108,7 @@ public:
   int GetTimersAmount();
   PVR_ERROR GetTimers(ADDON_HANDLE handle);
   PVR_ERROR AddTimer(const PVR_TIMER &timer);
-  PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bDeleteScheduled);
+  PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool force);
   PVR_ERROR UpdateTimer(const PVR_TIMER &timer);
   PVR_ERROR GetTimerTypes(PVR_TIMER_TYPE types[], int *size);
 


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.0.0, including a PVR addon micro version bump.

Details can be found here: https://github.com/xbmc/xbmc/pull/8005

@janbar and @metaron-uk already did a code review. Thx.
