### PR TITLE
Update to PVR addon API v4.1.0

### DIFF
--- a/pvr.mythtv/addon.xml.in
+++ b/pvr.mythtv/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mythtv"
-  version="3.3.5"
+  version="3.3.6"
   name="MythTV PVR Client"
   provider-name="Christian Fetzer, Jean-Luc Barrière">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="4.0.0"/>
+    <import addon="xbmc.pvr" version="4.1.0"/>
     <import addon="xbmc.gui" version="5.8.0"/>
     <import addon="xbmc.codec" version="1.0.1"/>
   </requires>

--- a/pvr.mythtv/changelog.txt
+++ b/pvr.mythtv/changelog.txt
@@ -1,8 +1,13 @@
+v3.3.6
+- Updated to PVR API v4.1.0
+
 v3.3.5
 - Fix issue when deleting timer rule since API v4.0.0
 
 v3.3.4
 - Updated to PVR API v4.0.0
+
+v3.3.3
 - Sync cppmyth upstream (2.3.1)
 
 v3.3.2

--- a/src/pvrclient-mythtv.cpp
+++ b/src/pvrclient-mythtv.cpp
@@ -562,6 +562,7 @@ PVR_ERROR PVRClientMythTV::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANN
       tag.strWriter = "";
       tag.iYear = 0;
       tag.strIMDBNumber = it->second->inetref.c_str();
+      tag.iFlags = EPG_TAG_FLAG_UNDEFINED;
 
       PVR->TransferEpgEntry(handle, &tag);
     }


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.1.0, including a PVR addon micro version bump.

Details can be found here: xbmc/xbmc#8075
