### PR TITLE
[cmake] Rename find_package(kodi) to Kodi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 enable_language(C)
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 

--- a/pvr.mythtv/addon.xml.in
+++ b/pvr.mythtv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mythtv"
-  version="4.4.1"
+  version="4.5.0"
   name="MythTV PVR Client"
   provider-name="Christian Fetzer, Jean-Luc Barrière">
   <requires>

--- a/pvr.mythtv/changelog.txt
+++ b/pvr.mythtv/changelog.txt
@@ -1,3 +1,6 @@
+v4.5.0
+- Cmake: rename find_package kodi to Kodi
+
 v4.4.1
 - Fix includes
 


### PR DESCRIPTION
Needed after https://github.com/xbmc/xbmc/pull/9750 goes in
